### PR TITLE
fix build failure by creating lib64 dir

### DIFF
--- a/MSPDebugStack_OS_Package/Makefile
+++ b/MSPDebugStack_OS_Package/Makefile
@@ -135,6 +135,7 @@ $(PCH_COMPILED): $(PCH_HEADER)
 	$(CXX) -c -o $@ $< $(USE_PCH) $(CXXFLAGS) $(INCLUDES) $(DEFINES)
 
 $(BSLLIB):
+	mkdir -p ./ThirdParty/lib64
 	$(MAKE) -C ./ThirdParty/BSL430_DLL
 
 install:


### PR DESCRIPTION
This patch makes the lib64 directory so that link operation doesn't fail